### PR TITLE
Fix Double Install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8793,9 +8793,9 @@
       }
     },
     "merge": {
-      "version": "1.2.0",
-      "resolved": "https://nexus.corp.mobile.de/nexus/repository/npm-all/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
       "dev": true
     },
     "merge-stream": {

--- a/packages/bricks/CHANGELOG.md
+++ b/packages/bricks/CHANGELOG.md
@@ -6,6 +6,8 @@
   changing routes with React Router. This was caused by the `withBricks` or `withBrick` HoC installing the same
   bricks multiple times. This was fixed.
 * Fixed vulnerability from `merge` module found by npm audit
+* Bugfix in utility function – `getValueByDottedPath` returned parent element if queried for non-existing child 
+  (now correctly returns null)
 
 ## 1.1.0 / 1 Nov 2018
 

--- a/packages/bricks/CHANGELOG.md
+++ b/packages/bricks/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.1 / 12 Nov 2018
+
+Bug fix – in some setups, the browser console showed error about a component changing state during render when 
+changing routes with React Router. This was caused by the `withBricks` or `withBrick` HoC installing the same
+bricks multiple times. This was fixed.
+
 ## 1.1.0 / 1 Nov 2018
 
 * Peer dependency of React at least version 16.3.0 required

--- a/packages/bricks/CHANGELOG.md
+++ b/packages/bricks/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## 1.1.1 / 12 Nov 2018
 
-Bug fix – in some setups, the browser console showed error about a component changing state during render when 
-changing routes with React Router. This was caused by the `withBricks` or `withBrick` HoC installing the same
-bricks multiple times. This was fixed.
+* Bug fix – in some setups, the browser console showed error about a component changing state during render when 
+  changing routes with React Router. This was caused by the `withBricks` or `withBrick` HoC installing the same
+  bricks multiple times. This was fixed.
+* Fixed vulnerability from `merge` module found by npm audit
 
 ## 1.1.0 / 1 Nov 2018
 

--- a/packages/bricks/README.md
+++ b/packages/bricks/README.md
@@ -85,6 +85,9 @@ This context provider wrapper allows you to pass a `BrickManager` instance to de
 the [React context API](https://reactjs.org/docs/context.html), similar to the Provider of
 [react-redux](https://redux.js.org/basics/usagewithreact#passing-the-store).
 
+**Important:** Make sure the brick provider is _inside_ the Redux `Provider` (as shown in the example below), but always
+_around_ all other components, _especially_ `BrowserRouter` from React Router.
+
 This example shows how to initialize Redux for your application, along with the `BrickProvider`:
 
 ```javascript

--- a/packages/bricks/src/BrickManager.js
+++ b/packages/bricks/src/BrickManager.js
@@ -1,21 +1,31 @@
 import { addValueByDottedPath, walkObject, getValueByDottedPath, filterObject, mergeObjects } from './utils';
 import { registerSelectorsForUseWithGlobalState } from '@modular-toolkit/selectors';
 
-const addReducer = Symbol(
+/* exported for testing only */
+export const addReducer = Symbol(
     process.env.NODE_ENV === 'production' ? undefined : 'addReducer (private method of BrickManager)'
 );
+
 const addSelectors = Symbol(
     process.env.NODE_ENV === 'production' ? undefined : 'addSelectors (private method of BrickManager)'
 );
+
 const addSaga = Symbol(process.env.NODE_ENV === 'production' ? undefined : 'addSaga (private method of BrickManager)');
+
 const createInitialReducer = Symbol(
     process.env.NODE_ENV === 'production' ? undefined : 'createInitialReducer (private method of BrickManager)'
 );
+
 const saveReducer = Symbol(
     process.env.NODE_ENV === 'production' ? undefined : 'saveReducer (private method of BrickManager)'
 );
+
 const loadReducer = Symbol(
     process.env.NODE_ENV === 'production' ? undefined : 'loadReducer (private method of BrickManager)'
+);
+
+const hasReducer = Symbol(
+    process.env.NODE_ENV === 'production' ? undefined : 'hasReducer (private method of BrickManager)'
 );
 
 const PREP_STATE = 'modular-toolkit/PREP_STATE';
@@ -37,6 +47,9 @@ export default class {
     }
 
     installBrick(storePath, { reducer, saga, selectors }) {
+        if (this[hasReducer](storePath)) {
+            return;
+        }
         this[addReducer](storePath, reducer);
         this[addSelectors](storePath, selectors);
         this[addSaga](saga);
@@ -101,5 +114,9 @@ export default class {
 
     [loadReducer](storePath) {
         return getValueByDottedPath(this.reducers, storePath);
+    }
+
+    [hasReducer](storePath) {
+        return this[loadReducer](storePath) !== null;
     }
 }

--- a/packages/bricks/src/BrickManager.test.js
+++ b/packages/bricks/src/BrickManager.test.js
@@ -1,4 +1,4 @@
-import BrickManager from './BrickManager';
+import BrickManager, { addReducer } from './BrickManager';
 import { createStore } from 'redux';
 import { registerSelectorsForUseWithGlobalState } from '@modular-toolkit/selectors';
 
@@ -79,8 +79,7 @@ describe('When I create a brick manager', () => {
             brickManager.installBricks({
                 'bricks.fasel': { reducer, saga, selectors },
                 'bricks.xyzzy': { reducer: otherReducer, saga: otherSaga, selectors: otherSelectors }
-            })
-        );
+            }));
         describe('the selectors of the first brick', () =>
             it('are registered for use with global state', () =>
                 expect(registerSelectorsForUseWithGlobalState).toHaveBeenCalledWith('bricks.fasel', selectors)));
@@ -157,6 +156,19 @@ describe('When I create a brick manager', () => {
                 });
             });
         });
+    });
+    describe('and I try to install the same Brick twice', () => {
+        let addReducerSpy;
+        beforeEach(() => {
+            addReducerSpy = jest.spyOn(brickManager, addReducer);
+            brickManager.installBrick('bricks.gnarg', { reducer, saga, selectors });
+            brickManager.installBrick('bricks.gnarg', { reducer, saga, selectors });
+        });
+        describe('the selectors', () =>
+            it('are registered for use with global state only once', () =>
+                expect(registerSelectorsForUseWithGlobalState).toHaveBeenCalledTimes(1)));
+        describe('the saga', () => it('is run only once', () => expect(sagaMiddleware.run).toHaveBeenCalledTimes(1)));
+        describe('the reducer', () => it('is stored only once', () => expect(addReducerSpy).toHaveBeenCalledTimes(1)));
     });
     afterEach(() => jest.clearAllMocks());
 });

--- a/packages/bricks/src/BrickManager.test.js
+++ b/packages/bricks/src/BrickManager.test.js
@@ -79,7 +79,8 @@ describe('When I create a brick manager', () => {
             brickManager.installBricks({
                 'bricks.fasel': { reducer, saga, selectors },
                 'bricks.xyzzy': { reducer: otherReducer, saga: otherSaga, selectors: otherSelectors }
-            }));
+            })
+        );
         describe('the selectors of the first brick', () =>
             it('are registered for use with global state', () =>
                 expect(registerSelectorsForUseWithGlobalState).toHaveBeenCalledWith('bricks.fasel', selectors)));

--- a/packages/bricks/src/utils/getValueByDottedPath.js
+++ b/packages/bricks/src/utils/getValueByDottedPath.js
@@ -4,6 +4,6 @@ export default (object, path) =>
     path
         .split('.')
         .reduce(
-            (acc, pathSegment) => (isObject(acc) ? (acc[pathSegment] === undefined ? null : acc[pathSegment]) : acc),
+            (acc, pathSegment) => (isObject(acc) ? (acc[pathSegment] === undefined ? null : acc[pathSegment]) : null),
             object
         );

--- a/packages/bricks/src/utils/getValueByDottedPath.test.js
+++ b/packages/bricks/src/utils/getValueByDottedPath.test.js
@@ -51,6 +51,16 @@ const testCases = [
         { bla: { di: { blub: 'BLUB' } }, gna: 'GNA' },
         'bla.di',
         { blub: 'BLUB' },
+    ],
+    [
+        { bla: () => {} },
+        'bla.di',
+        null
+    ],
+    [
+        { bla: 'bla' },
+        'bla.di',
+        null
     ]
 ];
 


### PR DESCRIPTION
* Bug fix – in some setups, the browser console showed error about a component changing state during render when 
  changing routes with React Router. This was caused by the `withBricks` or `withBrick` HoC installing the same
  bricks multiple times. This was fixed.
* Fixed vulnerability from `merge` module found by npm audit
